### PR TITLE
Dual number update

### DIFF
--- a/include/mathlib/dual_number.hpp
+++ b/include/mathlib/dual_number.hpp
@@ -1,0 +1,279 @@
+#ifndef MATHLIB_DUAL_NUMBER_HPP
+#define MATHLIB_DUAL_NUMBER_HPP
+
+#include <cmath>
+#include <concepts>
+
+namespace mathlib {
+
+template<std::floating_point T>
+struct Dual {
+    T a;
+    T b;
+
+    Dual() noexcept: a(0.0), b(0.0) {}
+    Dual(T a, T b) noexcept: a(a), b(b) {}
+
+
+    auto operator+=(const Dual<T>& x) noexcept -> Dual<T>& {
+        this->a += x.a;
+        this->b += x.b;
+        return *this;
+    }
+
+    auto operator-=(const Dual<T>& x) noexcept -> Dual<T>& {
+        this->a -= x.a;
+        this->b -= x.b;
+        return *this;
+    }
+
+    auto operator*=(const Dual<T>& x) noexcept -> Dual<T>& {
+        T a = this->a;
+        this->a = a * x.a;
+        this->b = a * x.b + this->b * x.a;
+        return *this;
+    }
+
+    auto operator/=(const Dual<T>& x) noexcept -> Dual<T>& {
+        T a = this->a;
+        this->a = a / x.a;
+        this->b = (this->b * x.a - a * x.b) / (x.a * x.a);
+        return *this;
+    }
+
+    auto operator+=(T alpha) noexcept -> Dual<T>& {
+        this->a += alpha;
+        return *this;
+    }
+
+    auto operator-=(T alpha) noexcept -> Dual<T>& {
+        this->a -= alpha;
+        return *this;
+    }
+
+    auto operator*=(T alpha) noexcept -> Dual<T>& {
+        this->a *= alpha;
+        this->b *= alpha;
+        return *this;
+    }
+
+    auto operator/=(T alpha) noexcept -> Dual<T>& {
+        this->a /= alpha;
+        this->b /= alpha;
+        return *this;
+    }
+};
+
+// ==== Implementation === //
+
+// ======================= //
+// Comparison operators    //
+// ======================= //
+
+/// @brief  Equality operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator==(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> bool {
+    return lhs.a == rhs.a && lhs.b == rhs.b;
+}
+
+/// @brief  Inequality operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator!=(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> bool {
+    return lhs.a != rhs.a || lhs.b != rhs.b;
+}
+
+
+// ======================= // 
+// Arithmetic operators    //
+// ======================= //
+
+/// @brief  Negation operator for dual numbers.
+template<std::floating_point T>
+auto operator-(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(-x.a, -x.b);
+}
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a + rhs.a, lhs.b + rhs.b);
+}
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a + alpha, lhs.b);
+}
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(alpha + rhs.a, rhs.b);
+}
+
+
+/// @brief  Subtraction operator for dual numbers. 
+template<std::floating_point T>
+constexpr auto operator-(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a - rhs.a, lhs.b - rhs.b);
+}
+
+/// @brief  Subtraction operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator-(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a - alpha, lhs.b);
+}
+
+/// @brief  Subtraction operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator-(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(alpha - rhs.a, -rhs.b);
+}
+
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a * rhs.a, lhs.a * rhs.b + lhs.b * rhs.a);
+}
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a * alpha, lhs.b * alpha);
+}
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(alpha * rhs.a, alpha * rhs.b);
+}
+
+
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a / rhs.a, (lhs.b * rhs.a - lhs.a * rhs.b) / (rhs.a * rhs.a));
+}
+
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
+    return Dual<T>(lhs.a / alpha, lhs.b / alpha);
+}
+
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
+    return Dual<T>(alpha / rhs.a, -alpha * rhs.b / (rhs.a * rhs.a));
+}
+
+
+/// @brief  Scalar multiplication for dual numbers.
+template<std::floating_point T>
+constexpr auto scale(T alpha, Dual<T>& x) noexcept -> Dual<T>& {
+    x.a *= alpha;
+    x.b *= alpha;
+    return x;
+}
+
+/// @brief  AXPY operation for dual numbers. (y = alpha * x + y)
+template<std::floating_point T>
+constexpr auto axpy(T alpha, const Dual<T>& x, Dual<T>& y) noexcept -> Dual<T>& {
+    y.a += alpha * x.a; 
+    y.b += alpha * x.b;
+    return y;
+}
+
+
+// ======================= //
+// Elementary functions    //
+// ======================= //
+
+/// @brief  Exponential function for dual numbers.
+template<std::floating_point T>
+constexpr auto exp(const Dual<T>& x) noexcept -> Dual<T> {
+    T exp_a = std::exp(x.a);
+    return Dual<T>(exp_a, x.b * exp_a);
+}
+
+/// @brief  Logarithm function for dual numbers.
+template<std::floating_point T>
+constexpr auto log(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(std::log(x.a), x.b / x.a);
+}
+
+/// @brief  Sine function for dual numbers.
+template<std::floating_point T>
+constexpr auto sin(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(std::sin(x.a), x.b * std::cos(x.a));
+}
+
+/// @brief  Cosine function for dual numbers.
+template<std::floating_point T>
+constexpr auto cos(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(std::cos(x.a), -x.b * std::sin(x.a));
+}
+
+/// @brief  Tangent function for dual numbers.
+template<std::floating_point T>
+constexpr auto tan(const Dual<T>& x) noexcept -> Dual<T> {
+    T cos_a = std::cos(x.a);
+    return Dual<T>(std::tan(x.a), x.b / (cos_a * cos_a));
+}
+
+/// @brief  Hyperbolic sine function for dual numbers.
+template<std::floating_point T>
+constexpr auto sinh(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(std::sinh(x.a), x.b * std::cosh(x.a));
+}
+
+/// @brief  Hyperbolic cosine function for dual numbers.
+template<std::floating_point T>
+constexpr auto cosh(const Dual<T>& x) noexcept -> Dual<T> {
+    return Dual<T>(std::cosh(x.a), x.b * std::sinh(x.a));
+}
+
+/// @brief  Hyperbolic tangent function for dual numbers.
+template<std::floating_point T>
+constexpr auto tanh(const Dual<T>& x) noexcept -> Dual<T> {
+    T cosh_a = std::cosh(x.a);
+    return Dual<T>(std::tanh(x.a), x.b / (cosh_a * cosh_a));
+}
+
+/// @brief  Power function for dual numbers.
+template<std::floating_point T>
+constexpr auto pow(const Dual<T>& x, T alpha) noexcept -> Dual<T> {
+    T pow_a = std::pow(x.a, alpha);
+    return Dual<T>(pow_a, alpha * pow_a * x.b / x.a);
+}
+
+/// @brief  Power function for dual numbers.
+template<std::floating_point T>
+constexpr auto pow(const Dual<T>& x, const Dual<T>& alpha) noexcept -> Dual<T> {
+    T pow_a = std::pow(x.a, alpha.a);
+    return Dual<T>(pow_a, pow_a * (alpha.b * std::log(x.a) + alpha.a * x.b / x.a));
+}
+
+/// @brief  Square root function for dual numbers.
+template<std::floating_point T>
+auto sqrt(const Dual<T>& x) noexcept -> Dual<T> {
+    T sqrt_a = std::sqrt(x.a);
+    return Dual<T>(sqrt_a, x.b / (2.0 * sqrt_a));
+}
+
+/// @brief  Absolute value function for dual numbers.
+template<std::floating_point T>
+auto abs(const Dual<T>& x) noexcept -> Dual<T> {
+    return x.a >= 0.0 ? x : -x;
+}
+
+/// @brief  Sign function for dual numbers.
+template<std::floating_point T>
+auto sign(const Dual<T>& x) noexcept -> Dual<T> {
+    return x.a > 0.0 ? Dual<T>(1.0, 0.0) : x.a < 0.0 ? Dual<T>(-1.0, 0.0) : Dual<T>(0.0, 0.0);
+}
+
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,3 +38,8 @@ gtest_discover_tests(mathlib_polynomial_test)
 add_executable(mathlib_rk_test ode/runge_kutta.cc)
 target_link_libraries(mathlib_rk_test PRIVATE  GTest::GTest GTest::Main)
 gtest_discover_tests(mathlib_rk_test)
+
+# Dual number
+add_executable(mathlib_dual_number_test dual_number.cc)
+target_link_libraries(mathlib_dual_number_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(mathlib_dual_number_test)

--- a/test/dual_number.cc
+++ b/test/dual_number.cc
@@ -1,0 +1,307 @@
+#include "mathlib/dual_number.hpp"
+#include <gtest/gtest.h>
+
+template<typename T>
+auto f1(T x) -> T { return x * sin(x); }
+
+template<typename T>
+auto df1(T x) -> T { return sin(x) + x * cos(x); }
+
+
+TEST(DualNumberTests, DerivationTest1) {
+    mathlib::Dual<double> x(1.0, 1.0);
+    mathlib::Dual<double> y = f1(x);
+    EXPECT_DOUBLE_EQ(y.a, f1(1.0));
+    EXPECT_DOUBLE_EQ(y.b, df1(1.0));
+}
+
+
+TEST(DualNumberTests, DualNumberAddition) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    mathlib::Dual<double> z = x + y;
+    EXPECT_DOUBLE_EQ(z.a, 4.0);
+    EXPECT_DOUBLE_EQ(z.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberSubtraction) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    mathlib::Dual<double> z = x - y;
+    EXPECT_DOUBLE_EQ(z.a, -2.0);
+    EXPECT_DOUBLE_EQ(z.b, -2.0);
+}
+
+TEST(DualNumberTests, DualNumberMultiplication) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    mathlib::Dual<double> z = x * y;
+    EXPECT_DOUBLE_EQ(z.a, 3.0);
+    EXPECT_DOUBLE_EQ(z.b, 10.0);
+}
+
+TEST(DualNumberTests, DualNumberDivision) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    mathlib::Dual<double> z = x / y;
+    EXPECT_DOUBLE_EQ(z.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(z.b, (2.0 * 3.0 - 1.0 * 4.0) / (3.0 * 3.0));
+}
+
+TEST(DualNumberTests, DualNumberScalarMultiplication) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = 2.0 * x;
+    EXPECT_DOUBLE_EQ(y.a, 2.0);
+    EXPECT_DOUBLE_EQ(y.b, 4.0);
+}
+
+TEST(DualNumberTests, DualNumberScalarDivision) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = x / 2.0;
+    EXPECT_DOUBLE_EQ(y.a, 0.5);
+    EXPECT_DOUBLE_EQ(y.b, 1.0);
+}
+
+TEST(DualNumberTests, DualNumberUnaryMinus) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = -x;
+    EXPECT_DOUBLE_EQ(y.a, -1.0);
+    EXPECT_DOUBLE_EQ(y.b, -2.0);
+}
+
+TEST(DualNumberTests, DualNumberAbs) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = abs(x);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberSign) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = sign(x);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 0.0);
+}
+
+TEST(DualNumberTests, DualNumberTan) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = tan(x);
+    EXPECT_DOUBLE_EQ(y.a, std::tan(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (std::cos(1.0) * std::cos(1.0)));
+}
+
+TEST(DualNumberTests, DualNumberSinh) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = sinh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::sinh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * std::cosh(1.0));
+}
+
+TEST(DualNumberTests, DualNumberCosh) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = cosh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::cosh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * std::sinh(1.0));
+}
+
+TEST(DualNumberTests, DualNumberTanh) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = tanh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::tanh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (std::cosh(1.0) * std::cosh(1.0)));
+}
+
+TEST(DualNumberTests, DualNumberPowScalar) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = pow(x, 2.0);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * 2.0 / 1.0);
+}
+
+TEST(DualNumberTests, DualNumberPowDual) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> alpha(3.0, 4.0);
+    mathlib::Dual<double> y = pow(x, alpha);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 1.0 * (4.0 * std::log(1.0) + 3.0 * 2.0 / 1.0));
+}
+
+TEST(DualNumberTests, DualNumberSqrt) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = sqrt(x);
+    EXPECT_DOUBLE_EQ(y.a, std::sqrt(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (2.0 * std::sqrt(1.0)));
+}
+
+TEST(DualNumberTests, DualNumberComparison) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(1.0, 2.0);
+    mathlib::Dual<double> z(2.0, 3.0);
+    EXPECT_TRUE(x == y);
+    EXPECT_FALSE(x == z);
+    EXPECT_FALSE(x != y);
+    EXPECT_TRUE(x != z);
+}
+
+
+TEST(DualNumberTests, DualNumberCopy) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(x);
+    EXPECT_DOUBLE_EQ(x.a, y.a);
+    EXPECT_DOUBLE_EQ(x.b, y.b);
+}
+
+TEST(DualNumberTests, DualNumberMove) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(std::move(x));
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignment) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y;
+    y = x;
+    EXPECT_DOUBLE_EQ(x.a, y.a);
+    EXPECT_DOUBLE_EQ(x.b, y.b);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentMove) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y;
+    y = std::move(x);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+
+TEST(DualNumberTests, DualNumberAssignmentAddition) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    x += y;
+    EXPECT_DOUBLE_EQ(x.a, 4.0);
+    EXPECT_DOUBLE_EQ(x.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentSubtraction) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    x -= y;
+    EXPECT_DOUBLE_EQ(x.a, -2.0);
+    EXPECT_DOUBLE_EQ(x.b, -2.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentMultiplication) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    x *= y;
+    EXPECT_DOUBLE_EQ(x.a, 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 10.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentDivision) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    x /= y;
+    EXPECT_DOUBLE_EQ(x.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(x.b, (2.0 * 3.0 - 1.0 * 4.0) / (3.0 * 3.0));
+}
+
+TEST(DualNumberTests, DualNumberAssignmentScalarAddition) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    x += 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 4.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentScalarSubtraction) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    x -= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, -2.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentScalarMultiplication) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    x *= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberAssignmentScalarDivision) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    x /= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0 / 3.0);
+}
+
+TEST(DualNumberTests, DualNumberAdditionScalar) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = x + 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 4.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberSubtractionScalar) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = x - 3.0;
+    EXPECT_DOUBLE_EQ(y.a, -2.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberMultiplicationScalar) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = x * 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberDivisionScalar) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = x / 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / 3.0);
+}
+
+TEST(DualNumberTests, DualNumberAdditionScalarReverse) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = 3.0 + x;
+    EXPECT_DOUBLE_EQ(y.a, 4.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+}
+
+TEST(DualNumberTests, DualNumberSubtractionScalarReverse) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = 3.0 - x;
+    EXPECT_DOUBLE_EQ(y.a, 2.0);
+    EXPECT_DOUBLE_EQ(y.b, -2.0);
+}
+
+TEST(DualNumberTests, DualNumberMultiplicationScalarReverse) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = 3.0 * x;
+    EXPECT_DOUBLE_EQ(y.a, 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberDivisionScalarReverse) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y = 3.0 / x;
+    EXPECT_DOUBLE_EQ(y.a, 3.0);
+    EXPECT_DOUBLE_EQ(y.b, -6.0);
+}
+
+TEST(DualNumberTests, DualNumberScale) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::scale(3.0, x);
+    EXPECT_DOUBLE_EQ(x.a, 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 6.0);
+}
+
+TEST(DualNumberTests, DualNumberAxpy) {
+    mathlib::Dual<double> x(1.0, 2.0);
+    mathlib::Dual<double> y(3.0, 4.0);
+    mathlib::axpy(2.0, x, y);
+    EXPECT_DOUBLE_EQ(y.a, 5.0);
+    EXPECT_DOUBLE_EQ(y.b, 8.0);
+}


### PR DESCRIPTION
This pull request introduces a new `Dual` number type to the `mathlib` library, including its implementation and corresponding unit tests. The changes span across multiple files, focusing on the definition, arithmetic operations, and elementary functions for dual numbers, as well as adding tests to ensure the correctness of these operations.

### Implementation of Dual Numbers:

* [`include/mathlib/dual_number.hpp`](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR1-R279): Added the `Dual` number type, including constructors, arithmetic operators, comparison operators, and elementary functions such as `exp`, `log`, `sin`, `cos`, and `tan`.

### Unit Tests for Dual Numbers:

* [`test/dual_number.cc`](diffhunk://#diff-98f426203b0b490c0bccc4f58de7cea850a9d84a05c52c5692d2e8f93e4762d0R1-R307): Added comprehensive unit tests for the `Dual` number type, covering basic arithmetic operations, scalar operations, elementary functions, and comparison operations.

### Build System Updates:

* [`test/CMakeLists.txt`](diffhunk://#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fdR41-R45): Updated the CMake configuration to include the new `mathlib_dual_number_test` executable and its dependencies.…tions