### PR TITLE
[ADD] add second derivative and hyper dual number tests for arithmetic operations

### DIFF
--- a/include/mathlib/dual_number.hpp
+++ b/include/mathlib/dual_number.hpp
@@ -64,6 +64,84 @@ struct Dual {
     }
 };
 
+template<std::floating_point T>
+struct HyperDual2 {
+    T a;
+    T b;
+    T c;
+    T d;
+
+    HyperDual2() noexcept: a(0.0), b(0.0), c(0.0), d(0.0) {}
+    HyperDual2(T a, T b, T c, T d) noexcept: a(a), b(b), c(c), d(d) {}
+
+    auto inv() const noexcept -> HyperDual2<T> {
+        T inv_a = 1.0 / this->a;
+        T inv_b = -this->b * inv_a * inv_a;
+        T inv_c = -this->c * inv_a * inv_a;
+        T inv_d = 2.0 * this->b * this->c * inv_a * inv_a * inv_a - this->d * inv_a * inv_a;
+
+        return HyperDual2<T>(inv_a, inv_b, inv_c, inv_d);
+    }
+
+    auto operator+=(const HyperDual2<T>& x) noexcept -> HyperDual2<T>& {
+        this->a += x.a;
+        this->b += x.b;
+        this->c += x.c;
+        this->d += x.d;
+        return *this;
+    }
+
+    auto operator-=(const HyperDual2<T>& x) noexcept -> HyperDual2<T>& {
+        this->a -= x.a;
+        this->b -= x.b;
+        this->c -= x.c;
+        this->d -= x.d;
+        return *this;
+    }
+
+    auto operator*=(const HyperDual2<T>& x) noexcept -> HyperDual2<T>& {
+        T a = this->a;
+        T b = this->b;
+        T c = this->c;
+        this->a = a * x.a;
+        this->b = a * x.b + b * x.a;
+        this->c = a * x.c + c * x.a;
+        this->d = a * x.d + this->d * x.a + b * x.c + c * x.b;
+        return *this;
+    }
+
+    auto operator/=(const HyperDual2<T>& x) noexcept -> HyperDual2<T>& {
+        HyperDual2<T> inv_x = x.inv();
+        return *this *= inv_x;
+    }
+
+    auto operator+=(T alpha) noexcept -> HyperDual2<T>& {
+        this->a += alpha;
+        return *this;
+    }
+
+    auto operator-=(T alpha) noexcept -> HyperDual2<T>& {
+        this->a -= alpha;
+        return *this;
+    }
+
+    auto operator*=(T alpha) noexcept -> HyperDual2<T>& {
+        this->a *= alpha;
+        this->b *= alpha;
+        this->c *= alpha;
+        this->d *= alpha;
+        return *this;
+    }
+
+    auto operator/=(T alpha) noexcept -> HyperDual2<T>& {
+        this->a /= alpha;
+        this->b /= alpha;
+        this->c /= alpha;
+        this->d /= alpha;
+        return *this;
+    }
+};
+
 // ==== Implementation === //
 
 // ======================= //
@@ -82,6 +160,18 @@ constexpr auto operator!=(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> bo
     return lhs.a != rhs.a || lhs.b != rhs.b;
 }
 
+/// @brief  Equality operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator==(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> bool {
+    return lhs.a == rhs.a && lhs.b == rhs.b && lhs.c == rhs.c;
+}
+
+/// @brief  Inequality operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator!=(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> bool {
+    return lhs.a != rhs.a || lhs.b != rhs.b || lhs.c != rhs.c;
+}
+
 
 // ======================= // 
 // Arithmetic operators    //
@@ -92,6 +182,13 @@ template<std::floating_point T>
 auto operator-(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(-x.a, -x.b);
 }
+
+/// @brief  Negation operator for dual numbers.
+template<std::floating_point T>
+auto operator-(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(-x.a, -x.b, -x.c, -x.d);
+}
+
 
 /// @brief  Addition operator for dual numbers.
 template<std::floating_point T>
@@ -109,6 +206,25 @@ constexpr auto operator+(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
 template<std::floating_point T>
 constexpr auto operator+(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
     return Dual<T>(alpha + rhs.a, rhs.b);
+}
+
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a + rhs.a, lhs.b + rhs.b, lhs.c + rhs.c, lhs.d + rhs.d);
+}
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(const HyperDual2<T>& lhs, T alpha) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a + alpha, lhs.b, lhs.c, lhs.d);
+}
+
+/// @brief  Addition operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator+(T alpha, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(alpha + rhs.a, rhs.b, rhs.c, rhs.d);
 }
 
 
@@ -131,6 +247,25 @@ constexpr auto operator-(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
 }
 
 
+/// @brief  Subtraction operator for dual numbers. 
+template<std::floating_point T>
+constexpr auto operator-(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a - rhs.a, lhs.b - rhs.b, lhs.c - rhs.c, lhs.d - rhs.d);
+}
+
+/// @brief  Subtraction operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator-(const HyperDual2<T>& lhs, T alpha) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a - alpha, lhs.b, lhs.c, lhs.d);
+}
+
+/// @brief  Subtraction operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator-(T alpha, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(alpha - rhs.a, -rhs.b, -rhs.c, -rhs.d);
+}
+
+
 /// @brief  Multiplication operator for dual numbers.
 template<std::floating_point T>
 constexpr auto operator*(const Dual<T>& lhs, const Dual<T>& rhs) noexcept -> Dual<T> {
@@ -147,6 +282,30 @@ constexpr auto operator*(const Dual<T>& lhs, T alpha) noexcept -> Dual<T> {
 template<std::floating_point T>
 constexpr auto operator*(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
     return Dual<T>(alpha * rhs.a, alpha * rhs.b);
+}
+
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        lhs.a * rhs.a, 
+        lhs.a * rhs.b + lhs.b * rhs.a, 
+        lhs.a * rhs.c + lhs.c * rhs.a,
+        lhs.a * rhs.d + lhs.d * rhs.a + lhs.b * rhs.c + lhs.c * rhs.b
+    );
+}
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(const HyperDual2<T>& lhs, T alpha) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a * alpha, lhs.b * alpha, lhs.c * alpha, lhs.d * alpha);
+}
+
+/// @brief  Multiplication operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator*(T alpha, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    return rhs * alpha;
 }
 
 
@@ -169,6 +328,27 @@ constexpr auto operator/(T alpha, const Dual<T>& rhs) noexcept -> Dual<T> {
 }
 
 
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(const HyperDual2<T>& lhs, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    HyperDual2<T> inv_rhs = rhs.inv();
+    return lhs * inv_rhs;
+}
+
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(const HyperDual2<T>& lhs, T alpha) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(lhs.a / alpha, lhs.b / alpha, lhs.c / alpha, lhs.d / alpha);
+}
+
+/// @brief  Division operator for dual numbers.
+template<std::floating_point T>
+constexpr auto operator/(T alpha, const HyperDual2<T>& rhs) noexcept -> HyperDual2<T> {
+    HyperDual2<T> inv_rhs = rhs.inv();
+    return alpha * inv_rhs;
+}
+
+
 /// @brief  Scalar multiplication for dual numbers.
 template<std::floating_point T>
 constexpr auto scale(T alpha, Dual<T>& x) noexcept -> Dual<T>& {
@@ -177,11 +357,31 @@ constexpr auto scale(T alpha, Dual<T>& x) noexcept -> Dual<T>& {
     return x;
 }
 
+/// @brief  Scalar multiplication for dual numbers.
+template<std::floating_point T>
+constexpr auto scale(T alpha, HyperDual2<T>& x) noexcept -> HyperDual2<T>& {
+    x.a *= alpha;
+    x.b *= alpha;
+    x.c *= alpha;
+    x.d *= alpha;
+    return x;
+}
+
 /// @brief  AXPY operation for dual numbers. (y = alpha * x + y)
 template<std::floating_point T>
 constexpr auto axpy(T alpha, const Dual<T>& x, Dual<T>& y) noexcept -> Dual<T>& {
     y.a += alpha * x.a; 
     y.b += alpha * x.b;
+    return y;
+}
+
+/// @brief  AXPY operation for dual numbers. (y = alpha * x + y)
+template<std::floating_point T>
+constexpr auto axpy(T alpha, const HyperDual2<T>& x, HyperDual2<T>& y) noexcept -> HyperDual2<T>& {
+    y.a += alpha * x.a; 
+    y.b += alpha * x.b;
+    y.c += alpha * x.c;
+    y.d += alpha * x.d;
     return y;
 }
 
@@ -197,11 +397,31 @@ constexpr auto exp(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(exp_a, x.b * exp_a);
 }
 
+/// @brief  Exponential function for dual numbers.
+template<std::floating_point T>
+constexpr auto exp(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    T exp_a = std::exp(x.a);
+    return HyperDual2<T>(exp_a, x.b * exp_a, x.c * exp_a, x.d * exp_a + x.b * x.c * exp_a);
+}
+
+
 /// @brief  Logarithm function for dual numbers.
 template<std::floating_point T>
 constexpr auto log(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(std::log(x.a), x.b / x.a);
 }
+
+/// @brief  Logarithm function for dual numbers.
+template<std::floating_point T>
+constexpr auto log(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        std::log(x.a), 
+        x.b / x.a, 
+        x.c / x.a, 
+        x.d / x.a - x.b * x.c / (x.a * x.a)
+    );
+}
+
 
 /// @brief  Sine function for dual numbers.
 template<std::floating_point T>
@@ -209,11 +429,35 @@ constexpr auto sin(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(std::sin(x.a), x.b * std::cos(x.a));
 }
 
+/// @brief  Sine function for dual numbers.
+template<std::floating_point T>
+constexpr auto sin(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        std::sin(x.a), 
+        x.b * std::cos(x.a), 
+        x.c * std::cos(x.a), 
+        x.d * std::cos(x.a) - x.b * x.c * std::sin(x.a)
+    );
+}
+
+
 /// @brief  Cosine function for dual numbers.
 template<std::floating_point T>
 constexpr auto cos(const Dual<T>& x) noexcept -> Dual<T> {
-    return Dual<T>(std::cos(x.a), -x.b * std::sin(x.a));
+    return Dual<T>(std::cos(x.a), -x.b * std::sin(x.a), -x.b * std::sin(x.a));
 }
+
+/// @brief  Cosine function for dual numbers.
+template<std::floating_point T>
+constexpr auto cos(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        std::cos(x.a), 
+        -x.b * std::sin(x.a), 
+        -x.c * std::sin(x.a), 
+        -x.d * std::sin(x.a) - x.b * x.c * std::cos(x.a)
+    );
+}
+
 
 /// @brief  Tangent function for dual numbers.
 template<std::floating_point T>
@@ -222,11 +466,36 @@ constexpr auto tan(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(std::tan(x.a), x.b / (cos_a * cos_a));
 }
 
+/// @brief  Tangent function for dual numbers.
+template<std::floating_point T>
+constexpr auto tan(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    T cos_a = std::cos(x.a);
+    return HyperDual2<T>(
+        std::tan(x.a), 
+        x.b / (cos_a * cos_a), 
+        x.c / (cos_a * cos_a), 
+        x.d / (cos_a * cos_a) + 2.0 * x.b * x.c * std::tan(x.a) / (cos_a * cos_a)
+    );
+}
+
+
 /// @brief  Hyperbolic sine function for dual numbers.
 template<std::floating_point T>
 constexpr auto sinh(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(std::sinh(x.a), x.b * std::cosh(x.a));
 }
+
+/// @brief  Hyperbolic sine function for dual numbers.
+template<std::floating_point T>
+constexpr auto sinh(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        std::sinh(x.a), 
+        x.b * std::cosh(x.a), 
+        x.c * std::cosh(x.a), 
+        x.d * std::cosh(x.a) + x.b * x.c * std::sinh(x.a)
+    );
+}
+
 
 /// @brief  Hyperbolic cosine function for dual numbers.
 template<std::floating_point T>
@@ -234,12 +503,37 @@ constexpr auto cosh(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(std::cosh(x.a), x.b * std::sinh(x.a));
 }
 
+/// @brief  Hyperbolic cosine function for dual numbers.
+template<std::floating_point T>
+constexpr auto cosh(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    return HyperDual2<T>(
+        std::cosh(x.a), 
+        x.b * std::sinh(x.a), 
+        x.c * std::sinh(x.a), 
+        x.d * std::sinh(x.a) + x.b * x.c * std::cosh(x.a)
+    );
+}
+
+
 /// @brief  Hyperbolic tangent function for dual numbers.
 template<std::floating_point T>
 constexpr auto tanh(const Dual<T>& x) noexcept -> Dual<T> {
     T cosh_a = std::cosh(x.a);
     return Dual<T>(std::tanh(x.a), x.b / (cosh_a * cosh_a));
 }
+
+/// @brief  Hyperbolic tangent function for dual numbers.
+template<std::floating_point T>
+constexpr auto tanh(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    T cosh_a = std::cosh(x.a);
+    return HyperDual2<T>(
+        std::tanh(x.a), 
+        x.b / (cosh_a * cosh_a), 
+        x.c / (cosh_a * cosh_a),
+        x.d / (cosh_a * cosh_a) + 2.0 * x.b * x.c * std::tanh(x.a) / (cosh_a * cosh_a)
+    );
+}
+
 
 /// @brief  Power function for dual numbers.
 template<std::floating_point T>
@@ -250,10 +544,43 @@ constexpr auto pow(const Dual<T>& x, T alpha) noexcept -> Dual<T> {
 
 /// @brief  Power function for dual numbers.
 template<std::floating_point T>
+constexpr auto pow(T alpha, const Dual<T>& x) noexcept -> Dual<T> {
+    T pow_a = std::pow(alpha, x.a);
+    return Dual<T>(pow_a, pow_a * x.b * std::log(alpha));
+}
+
+
+/// @brief  Power function for dual numbers.
+template<std::floating_point T>
 constexpr auto pow(const Dual<T>& x, const Dual<T>& alpha) noexcept -> Dual<T> {
     T pow_a = std::pow(x.a, alpha.a);
     return Dual<T>(pow_a, pow_a * (alpha.b * std::log(x.a) + alpha.a * x.b / x.a));
 }
+
+/// @brief  Power function for dual numbers.
+template<std::floating_point T>
+constexpr auto pow(const HyperDual2<T>& x, T alpha) noexcept -> HyperDual2<T> {
+    T pow_a = std::pow(x.a, alpha);
+    return HyperDual2<T>(
+        pow_a, 
+        x.b * alpha * std::pow(x.a, alpha - 1.0),
+        x.c * alpha * std::pow(x.a, alpha - 1.0),
+        x.d * alpha * std::pow(x.a, alpha - 1.0) + x.b * x.c * alpha * (alpha - 1.0) * std::pow(x.a, alpha - 2.0)
+    );
+}
+
+/// @brief  Power function for dual numbers.
+template<std::floating_point T>
+constexpr auto pow(T alpha, const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    T pow_a = std::pow(alpha, x.a);
+    return HyperDual2<T>(
+        pow_a, 
+        pow_a * x.b * std::log(alpha), 
+        pow_a * x.c * std::log(alpha),
+        pow_a * x.d * std::log(alpha) + pow_a * x.b * x.c * std::log(alpha) * std::log(alpha)
+    );
+}
+
 
 /// @brief  Square root function for dual numbers.
 template<std::floating_point T>
@@ -262,16 +589,16 @@ auto sqrt(const Dual<T>& x) noexcept -> Dual<T> {
     return Dual<T>(sqrt_a, x.b / (2.0 * sqrt_a));
 }
 
-/// @brief  Absolute value function for dual numbers.
+/// @brief  Square root function for dual numbers.
 template<std::floating_point T>
-auto abs(const Dual<T>& x) noexcept -> Dual<T> {
-    return x.a >= 0.0 ? x : -x;
-}
-
-/// @brief  Sign function for dual numbers.
-template<std::floating_point T>
-auto sign(const Dual<T>& x) noexcept -> Dual<T> {
-    return x.a > 0.0 ? Dual<T>(1.0, 0.0) : x.a < 0.0 ? Dual<T>(-1.0, 0.0) : Dual<T>(0.0, 0.0);
+auto sqrt(const HyperDual2<T>& x) noexcept -> HyperDual2<T> {
+    T sqrt_a = std::sqrt(x.a);
+    return HyperDual2<T>(
+        sqrt_a,
+        x.b / (2.0 * sqrt_a),
+        x.c / (2.0 * sqrt_a),
+        x.d / (2.0 * sqrt_a) - x.b * x.c / (4.0 * x.a * sqrt_a)
+    );
 }
 
 }

--- a/test/dual_number.cc
+++ b/test/dual_number.cc
@@ -7,12 +7,24 @@ auto f1(T x) -> T { return x * sin(x); }
 template<typename T>
 auto df1(T x) -> T { return sin(x) + x * cos(x); }
 
+template<typename T>
+auto ddf1(T x) -> T { return 2.0 * cos(x) - x * sin(x); }
+
 
 TEST(DualNumberTests, DerivationTest1) {
     mathlib::Dual<double> x(1.0, 1.0);
     mathlib::Dual<double> y = f1(x);
     EXPECT_DOUBLE_EQ(y.a, f1(1.0));
     EXPECT_DOUBLE_EQ(y.b, df1(1.0));
+}
+
+TEST(DualNumberTests, SecDerivationTest1) {
+    mathlib::HyperDual2<double> x(1.0, 1.0, 1.0, 0.0);
+    mathlib::HyperDual2<double> y = f1(x);
+    EXPECT_DOUBLE_EQ(y.a, f1(1.0));
+    EXPECT_DOUBLE_EQ(y.b, df1(1.0));
+    EXPECT_DOUBLE_EQ(y.c, df1(1.0));
+    EXPECT_DOUBLE_EQ(y.d, ddf1(1.0));
 }
 
 
@@ -67,20 +79,6 @@ TEST(DualNumberTests, DualNumberUnaryMinus) {
     mathlib::Dual<double> y = -x;
     EXPECT_DOUBLE_EQ(y.a, -1.0);
     EXPECT_DOUBLE_EQ(y.b, -2.0);
-}
-
-TEST(DualNumberTests, DualNumberAbs) {
-    mathlib::Dual<double> x(1.0, 2.0);
-    mathlib::Dual<double> y = abs(x);
-    EXPECT_DOUBLE_EQ(y.a, 1.0);
-    EXPECT_DOUBLE_EQ(y.b, 2.0);
-}
-
-TEST(DualNumberTests, DualNumberSign) {
-    mathlib::Dual<double> x(1.0, 2.0);
-    mathlib::Dual<double> y = sign(x);
-    EXPECT_DOUBLE_EQ(y.a, 1.0);
-    EXPECT_DOUBLE_EQ(y.b, 0.0);
 }
 
 TEST(DualNumberTests, DualNumberTan) {
@@ -304,4 +302,316 @@ TEST(DualNumberTests, DualNumberAxpy) {
     mathlib::axpy(2.0, x, y);
     EXPECT_DOUBLE_EQ(y.a, 5.0);
     EXPECT_DOUBLE_EQ(y.b, 8.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAddition) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    mathlib::HyperDual2<double> z = x + y;
+    EXPECT_DOUBLE_EQ(z.a, 5.0);
+    EXPECT_DOUBLE_EQ(z.b, 7.0);
+    EXPECT_DOUBLE_EQ(z.c, 9.0);
+    EXPECT_DOUBLE_EQ(z.d, 11.0);
+}
+
+
+TEST(DualNumberTests, HyperDualNumberSubtraction) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    mathlib::HyperDual2<double> z = x - y;
+    EXPECT_DOUBLE_EQ(z.a, -3.0);
+    EXPECT_DOUBLE_EQ(z.b, -3.0);
+    EXPECT_DOUBLE_EQ(z.c, -3.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberInversion) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x.inv();
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, -2.0);
+    EXPECT_DOUBLE_EQ(y.c, -3.0);
+    EXPECT_DOUBLE_EQ(y.d, 12.0 - 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberMulDiv) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    auto y = x.inv();
+    auto z = x * y;
+    EXPECT_DOUBLE_EQ(z.a, 1.0);
+    EXPECT_DOUBLE_EQ(z.b, 0.0);
+    EXPECT_DOUBLE_EQ(z.c, 0.0);
+    EXPECT_DOUBLE_EQ(z.d, 0.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberScalarMultiplication) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = 2.0 * x;
+    EXPECT_DOUBLE_EQ(y.a, 2.0);
+    EXPECT_DOUBLE_EQ(y.b, 4.0);
+    EXPECT_DOUBLE_EQ(y.c, 6.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberScalarDivision) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x / 2.0;
+    EXPECT_DOUBLE_EQ(y.a, 0.5);
+    EXPECT_DOUBLE_EQ(y.b, 1.0);
+    EXPECT_DOUBLE_EQ(y.c, 1.5);
+}
+
+TEST(DualNumberTests, HyperDualNumberUnaryMinus) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = -x;
+    EXPECT_DOUBLE_EQ(y.a, -1.0);
+    EXPECT_DOUBLE_EQ(y.b, -2.0);
+    EXPECT_DOUBLE_EQ(y.c, -3.0);
+    EXPECT_DOUBLE_EQ(y.d, -4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberTan) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = tan(x);
+    EXPECT_DOUBLE_EQ(y.a, std::tan(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (std::cos(1.0) * std::cos(1.0)));
+    EXPECT_DOUBLE_EQ(y.c, 3.0 / (std::cos(1.0) * std::cos(1.0)));
+    EXPECT_DOUBLE_EQ(y.d, 4.0 / (std::cos(1.0) * std::cos(1.0)) + 6.0 * 2.0 * std::tan(1.0) / (std::cos(1.0) * std::cos(1.0)));
+}
+
+TEST(DualNumberTests, HyperDualNumberSinh) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = sinh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::sinh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * std::cosh(1.0));
+    EXPECT_DOUBLE_EQ(y.c, 3.0 * std::cosh(1.0));
+    EXPECT_DOUBLE_EQ(y.d, 4.0 * std::cosh(1.0) + 6.0 * std::sinh(1.0));
+}
+
+TEST(DualNumberTests, HyperDualNumberCosh) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = cosh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::cosh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * std::sinh(1.0));
+    EXPECT_DOUBLE_EQ(y.c, 3.0 * std::sinh(1.0));
+    EXPECT_DOUBLE_EQ(y.d, 4.0 * std::sinh(1.0) + 6.0 * std::cosh(1.0));
+}
+
+TEST(DualNumberTests, HyperDualNumberTanh) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = tanh(x);
+    EXPECT_DOUBLE_EQ(y.a, std::tanh(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (std::cosh(1.0) * std::cosh(1.0)));
+    EXPECT_DOUBLE_EQ(y.c, 3.0 / (std::cosh(1.0) * std::cosh(1.0)));
+    EXPECT_DOUBLE_EQ(y.d, 4.0 / (std::cosh(1.0) * std::cosh(1.0)) + 6.0 * 2.0 * std::tanh(1.0) / (std::cosh(1.0) * std::cosh(1.0)));
+}
+
+TEST(DualNumberTests, HyperDualNumberPowScalar) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = pow(x, 2.0);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0 * 2.0 / 1.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0 * 2.0 / 1.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0 * 2.0 / 1.0 + 6.0 * 2.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberSqrt) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = sqrt(x);
+    EXPECT_DOUBLE_EQ(y.a, std::sqrt(1.0));
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / (2.0 * std::sqrt(1.0)));
+    EXPECT_DOUBLE_EQ(y.c, 3.0 / (2.0 * std::sqrt(1.0)));
+    EXPECT_DOUBLE_EQ(y.d, 4.0 / (2.0 * std::sqrt(1.0)) - 6.0 / (4.0 * std::pow(1.0, 3.0/2.0)));
+}
+
+TEST(DualNumberTests, HyperDualNumberComparison) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> z(2.0, 3.0, 4.0, 5.0);
+    EXPECT_TRUE(x == y);
+    EXPECT_FALSE(x == z);
+    EXPECT_FALSE(x != y);
+    EXPECT_TRUE(x != z);
+}
+
+TEST(DualNumberTests, HyperDualNumberCopy) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(x);
+    EXPECT_DOUBLE_EQ(x.a, y.a);
+    EXPECT_DOUBLE_EQ(x.b, y.b);
+    EXPECT_DOUBLE_EQ(x.c, y.c);
+}
+
+TEST(DualNumberTests, HyperDualNumberMove) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(std::move(x));
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignment) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y;
+    y = x;
+    EXPECT_DOUBLE_EQ(x.a, y.a);
+    EXPECT_DOUBLE_EQ(x.b, y.b);
+    EXPECT_DOUBLE_EQ(x.c, y.c);
+    EXPECT_DOUBLE_EQ(x.d, y.d);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentMove) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y;
+    y = std::move(x);
+    EXPECT_DOUBLE_EQ(y.a, 1.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignementAddition) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    x += y;
+    EXPECT_DOUBLE_EQ(x.a, 5.0);
+    EXPECT_DOUBLE_EQ(x.b, 7.0);
+    EXPECT_DOUBLE_EQ(x.c, 9.0);
+    EXPECT_DOUBLE_EQ(x.d, 11.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignementSubtraction) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    x -= y;
+    EXPECT_DOUBLE_EQ(x.a, -3.0);
+    EXPECT_DOUBLE_EQ(x.b, -3.0);
+    EXPECT_DOUBLE_EQ(x.c, -3.0);
+    EXPECT_DOUBLE_EQ(x.d, -3.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentMultiplication) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    x *= y;
+    EXPECT_DOUBLE_EQ(x.a, 4.0);
+    EXPECT_DOUBLE_EQ(x.b, 13.0);
+    EXPECT_DOUBLE_EQ(x.c, 18.0);
+    EXPECT_DOUBLE_EQ(x.d, 50.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentScalarAddition) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    x += 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 4.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0);
+    EXPECT_DOUBLE_EQ(x.c, 3.0);
+    EXPECT_DOUBLE_EQ(x.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentScalarSubtraction) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    x -= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, -2.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0);
+    EXPECT_DOUBLE_EQ(x.c, 3.0);
+    EXPECT_DOUBLE_EQ(x.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentScalarMultiplication) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    x *= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 6.0);
+    EXPECT_DOUBLE_EQ(x.c, 9.0);
+    EXPECT_DOUBLE_EQ(x.d, 12.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAssignmentScalarDivision) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    x /= 3.0;
+    EXPECT_DOUBLE_EQ(x.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 2.0 / 3.0);
+    EXPECT_DOUBLE_EQ(x.c, 3.0 / 3.0);
+    EXPECT_DOUBLE_EQ(x.d, 4.0 / 3.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAdditionScalar) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x + 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 4.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberSubtractionScalar) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x - 3.0;
+    EXPECT_DOUBLE_EQ(y.a, -2.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberMultiplicationScalar) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x * 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 6.0);
+    EXPECT_DOUBLE_EQ(y.c, 9.0);
+    EXPECT_DOUBLE_EQ(y.d, 12.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberDivisionScalar) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = x / 3.0;
+    EXPECT_DOUBLE_EQ(y.a, 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0 / 3.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0 / 3.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0 / 3.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAdditionScalarReverse) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = 3.0 + x;
+    EXPECT_DOUBLE_EQ(y.a, 4.0);
+    EXPECT_DOUBLE_EQ(y.b, 2.0);
+    EXPECT_DOUBLE_EQ(y.c, 3.0);
+    EXPECT_DOUBLE_EQ(y.d, 4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberSubtractionScalarReverse) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = 3.0 - x;
+    EXPECT_DOUBLE_EQ(y.a, 2.0);
+    EXPECT_DOUBLE_EQ(y.b, -2.0);
+    EXPECT_DOUBLE_EQ(y.c, -3.0);
+    EXPECT_DOUBLE_EQ(y.d, -4.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberMultiplicationScalarReverse) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y = 3.0 * x;
+    EXPECT_DOUBLE_EQ(y.a, 3.0);
+    EXPECT_DOUBLE_EQ(y.b, 6.0);
+    EXPECT_DOUBLE_EQ(y.c, 9.0);
+    EXPECT_DOUBLE_EQ(y.d, 12.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberScale) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::scale(3.0, x);
+    EXPECT_DOUBLE_EQ(x.a, 3.0);
+    EXPECT_DOUBLE_EQ(x.b, 6.0);
+    EXPECT_DOUBLE_EQ(x.c, 9.0);
+    EXPECT_DOUBLE_EQ(x.d, 12.0);
+}
+
+TEST(DualNumberTests, HyperDualNumberAxpy) {
+    mathlib::HyperDual2<double> x(1.0, 2.0, 3.0, 4.0);
+    mathlib::HyperDual2<double> y(4.0, 5.0, 6.0, 7.0);
+    mathlib::axpy(2.0, x, y);
+    EXPECT_DOUBLE_EQ(y.a, 6.0);
+    EXPECT_DOUBLE_EQ(y.b, 9.0);
+    EXPECT_DOUBLE_EQ(y.c, 12.0);
+    EXPECT_DOUBLE_EQ(y.d, 15.0);
 }


### PR DESCRIPTION
This pull request introduces a new `HyperDual2` struct to the `mathlib` library, providing extended functionality for dual numbers, including arithmetic operations and elementary functions. It also adds corresponding unit tests to verify the correctness of these operations.

### Additions to `mathlib` library:

* `include/mathlib/dual_number.hpp`:
  * Added `HyperDual2` struct with member variables `a`, `b`, `c`, and `d`, and implemented member functions for inversion, addition, subtraction, multiplication, and division.
  * Added equality and inequality operators for `HyperDual2`.
  * Added negation operator for `HyperDual2`.
  * Added arithmetic operators (addition, subtraction, multiplication, division) for `HyperDual2` with both `HyperDual2` and scalar types. [[1]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR212-R230) [[2]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR250-R268) [[3]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR288-R311) [[4]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR331-R351)
  * Added scalar multiplication and AXPY operation for `HyperDual2`. [[1]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR360-R369) [[2]](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR378-R387)
  * Added elementary functions (exp, log, sin, cos, tan, sinh, cosh, tanh, pow, sqrt) for `HyperDual2`.

### Unit tests:

* `test/dual_number.cc`:
  * Added `ddf1` function to compute the second derivative of the test function `f1`.
  * Added `SecDerivationTest1` to test second-order derivatives using `HyperDual2`.

### Removals:

* `include/mathlib/dual_number.hpp`:
  * Removed `abs` and `sign` functions for `Dual`.
* `test/dual_number.cc`:
  * Removed unit tests for `abs` and `sign` functions of `Dual`.