### PR TITLE
Brief Dual Number Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(mathlib VERSION 0.9.1 LANGUAGES C CXX)
+project(mathlib VERSION 0.9.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/mathlib/dual_number.hpp
+++ b/include/mathlib/dual_number.hpp
@@ -11,8 +11,14 @@ struct Dual {
     T a;
     T b;
 
+    /// @brief  Default constructor.
     Dual() noexcept: a(0.0), b(0.0) {}
+
+    /// @brief  Constructor with two parameters for initializing the dual number.
     Dual(T a, T b) noexcept: a(a), b(b) {}
+
+    /// @brief  Create a dual number from a real number.
+    Dual(T a) noexcept: a(a), b(0.0) {}
 
 
     auto operator+=(const Dual<T>& x) noexcept -> Dual<T>& {
@@ -71,8 +77,15 @@ struct HyperDual2 {
     T c;
     T d;
 
+    /// @brief  Default constructor.
     HyperDual2() noexcept: a(0.0), b(0.0), c(0.0), d(0.0) {}
+
+    /// @brief  Constructor with four parameters for initializing the hyper-dual number.
     HyperDual2(T a, T b, T c, T d) noexcept: a(a), b(b), c(c), d(d) {}
+
+    /// @brief  Create a hyper-dual number from a real number.
+    HyperDual2(T a) noexcept: a(a), b(0.0), c(0.0), d(0.0) {}
+
 
     auto inv() const noexcept -> HyperDual2<T> {
         T inv_a = 1.0 / this->a;


### PR DESCRIPTION
This pull request includes updates to the `mathlib` project, specifically versioning changes and enhancements to the `Dual` and `HyperDual2` structures in the `dual_number.hpp` file. The most important changes are as follows:

Versioning update:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2): Updated the project version from `0.9.1` to `0.9.2`.

Enhancements to `Dual` structure:
* [`include/mathlib/dual_number.hpp`](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR14-R22): Added a default constructor, a constructor with two parameters, and a constructor to create a dual number from a real number to the `Dual` structure.

Enhancements to `HyperDual2` structure:
* [`include/mathlib/dual_number.hpp`](diffhunk://#diff-a3d2c914dda358d75a35386ccecc79c1f9c71010a5492bee557566d8ca7a543fR80-R89): Added a default constructor, a constructor with four parameters, and a constructor to create a hyper-dual number from a real number to the `HyperDual2` structure.