### PR TITLE
dual number support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(mathlib VERSION 0.9.2 LANGUAGES C CXX)
+project(mathlib VERSION 0.9.3 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/mathlib/interpolation/linear.hpp
+++ b/include/mathlib/interpolation/linear.hpp
@@ -9,6 +9,7 @@
 #include "lalib/vec.hpp"
 #include "lalib/mat.hpp"
 #include "lalib/solver/tri_diag.hpp"
+#include "mathlib/dual_number.hpp"
 
 namespace mathlib::intrpl {
 
@@ -22,6 +23,8 @@ public:
 
 	/// @brief Returns the interpolated value at given 'x'.
 	auto operator()(double x) const noexcept -> T;
+	auto operator()(const Dual<double>& x) const noexcept -> Dual<T>;
+	auto operator()(const HyperDual2<double>& x) const noexcept -> HyperDual2<T>;
 
 	auto n_nodes() const noexcept -> size_t;
 	auto n_segments() const noexcept -> size_t;
@@ -34,6 +37,8 @@ public:
 
 private:
 	std::vector<std::pair<double, T>> _nodes;
+
+	auto _find_segment(double x) const noexcept -> size_t;
 };
 
 template <typename T>
@@ -53,21 +58,106 @@ inline auto Linear<T>::operator()(double x) const noexcept -> T
 	if (x < this->_nodes.front().first) {
 		return this->_nodes.front().second;
 	}
-	for (auto i = 1u; i < this->_nodes.size(); ++i) {
-		// Each data must be sorted in ascending order.
-		assert(this->_nodes[i].first >= this->_nodes[i - 1].first && "dataset must be sorted in ascending order");
 
-		if (x < this->_nodes[i].first) {
-			auto&& s0 = this->_nodes[i - 1].first;
-			auto&& s1 = this->_nodes[i].first;
-			auto ds = s1 - s0;
-			auto s_loc = (x - s0) / ds;
+	size_t i = this->_find_segment(x);
 
-			auto tmp = s_loc * this->_nodes[i].second + (1 - s_loc) * this->_nodes[i - 1].second;
-			return tmp;
-		}
+	if (i == this->_nodes.size() - 1) {
+		return this->_nodes.back().second;
 	}
-	return this->_nodes.back().second;
+
+	auto&& s0 = this->_nodes[i].first;
+	auto&& s1 = this->_nodes[i + 1].first;
+	auto&& f0 = this->_nodes[i].second;
+	auto&& f1 = this->_nodes[i + 1].second;
+	auto ds = s1 - s0;
+	auto s_loc = (x - s0) / ds;
+
+	auto tmp = s_loc * f1 + (1 - s_loc) * f0;
+	return tmp;
+}
+
+template<typename T>
+inline auto Linear<T>::operator()(const Dual<double>& x) const noexcept -> Dual<T> {
+	if (x.a < this->_nodes.front().first) {
+		T f = this->_nodes.front().second;
+
+		auto&& s0 = this->_nodes[0].first;
+		auto&& s1 = this->_nodes[1].first;
+		auto&& f0 = this->_nodes[0].second;
+		auto&& f1 = this->_nodes[1].second;
+		auto ds = s1 - s0;
+		auto df = f1 - f0;
+
+		return Dual<T>(f, x.b * df / ds);
+	}
+
+	size_t i = this->_find_segment(x.a);
+
+	if (i == this->_nodes.size() - 1) {
+		T f = this->_nodes.back().second;
+
+		auto&& s0 = this->_nodes[i - 1].first;
+		auto&& s1 = this->_nodes[i].first;
+		auto&& f0 = this->_nodes[i - 1].second;
+		auto&& f1 = this->_nodes[i].second;
+		auto ds = s1 - s0;
+		auto df = f1 - f0;
+
+		return Dual<T>(f, x.b * df / ds);
+	}
+
+	auto&& s0 = this->_nodes[i].first;
+	auto&& s1 = this->_nodes[i + 1].first;
+	auto&& f0 = this->_nodes[i].second;
+	auto&& f1 = this->_nodes[i + 1].second;
+	auto ds = s1 - s0;
+	auto df = f1 - f0;
+	auto s_loc = (x.a - s0) / ds;
+
+	auto f = s_loc * f1 + (1 - s_loc) * f0;
+	return Dual<T>(f, x.b * df / ds);
+}
+
+template<typename T>
+inline auto Linear<T>::operator()(const HyperDual2<double>& x) const noexcept -> HyperDual2<T> {
+	if (x.a < this->_nodes.front().first) {
+		T f = this->_nodes.front().second;
+
+		auto&& s0 = this->_nodes[0].first;
+		auto&& s1 = this->_nodes[1].first;
+		auto&& f0 = this->_nodes[0].second;
+		auto&& f1 = this->_nodes[1].second;
+		auto ds = s1 - s0;
+		auto df = f1 - f0;
+
+		return HyperDual2<T>(f, x.b * df / ds, x.c * df / ds, x.d * df / ds);
+	}
+
+	size_t i = this->_find_segment(x.a);
+
+	if (i == this->_nodes.size() - 1) {
+		T f = this->_nodes.back().second;
+
+		auto&& s0 = this->_nodes[i - 1].first;
+		auto&& s1 = this->_nodes[i].first;
+		auto&& f0 = this->_nodes[i - 1].second;
+		auto&& f1 = this->_nodes[i].second;
+		auto ds = s1 - s0;
+		auto df = f1 - f0;
+
+		return HyperDual2<T>(f, x.b * df / ds, x.c * df / ds, x.d * df / ds);
+	}
+
+	auto&& s0 = this->_nodes[i].first;
+	auto&& s1 = this->_nodes[i + 1].first;
+	auto&& f0 = this->_nodes[i].second;
+	auto&& f1 = this->_nodes[i + 1].second;
+	auto ds = s1 - s0;
+	auto df = f1 - f0;
+	auto s_loc = (x.a - s0) / ds;
+
+	auto f = s_loc * f1 + (1 - s_loc) * f0;
+	return HyperDual2<T>(f, x.b * df / ds, x.c * df / ds, x.d * df / ds);
 }
 
 template <typename T>
@@ -96,6 +186,21 @@ inline auto Linear<T>::domain() const noexcept -> std::pair<double, double>
 	);
 	return dom;
 }
+
+template <typename T>
+inline auto Linear<T>::_find_segment(double x) const noexcept -> size_t
+{
+	for (auto i = 1u; i < this->_nodes.size(); ++i) {
+		// Each data must be sorted in ascending order.
+		assert(this->_nodes[i].first >= this->_nodes[i - 1].first && "dataset must be sorted in ascending order");
+
+		if (x < this->_nodes[i].first) {
+			return i - 1;
+		}
+	}
+	return this->_nodes.size() - 1;
+}
+
 }
 
 #endif

--- a/test/interpolation/cubic_spline.cc
+++ b/test/interpolation/cubic_spline.cc
@@ -27,3 +27,44 @@ TEST(CubicSplineTests, InterpolationTest) {
 
     print_spline(f, 100);
 }
+
+TEST(CubicSplineTests, InterpolationDualTest) {
+    auto data = std::vector {
+        std::make_pair(0.0, 1.0),
+        std::make_pair(0.5, -1.0),
+        std::make_pair(1.0, 4.0),
+        std::make_pair(2.0, 3.0),
+        std::make_pair(4.0, 7.0),
+    };
+    auto f = mathlib::CubicSpline(data);
+
+    ASSERT_EQ(4, f.n_segments());
+
+    auto x0 = mathlib::Dual(0.0, 1.0);
+    auto x1 = mathlib::Dual(4.0, 1.0);
+
+    EXPECT_DOUBLE_EQ(1.0, f(x0).a);
+    EXPECT_DOUBLE_EQ(7.0, f(x1).a);
+}
+
+TEST(CubicSplineTests, InterpolationHyperDualTest) {
+    auto data = std::vector {
+        std::make_pair(0.0, 1.0),
+        std::make_pair(0.5, -1.0),
+        std::make_pair(1.0, 4.0),
+        std::make_pair(2.0, 3.0),
+        std::make_pair(4.0, 7.0),
+    };
+    auto f = mathlib::CubicSpline(data);
+
+    ASSERT_EQ(4, f.n_segments());
+
+    auto x0 = mathlib::HyperDual2(0.0, 1.0, 1.0, 0.0);
+    auto x1 = mathlib::HyperDual2(4.0, 1.0, 1.0, 0.0);
+
+    EXPECT_DOUBLE_EQ(1.0, f(x0).a);
+    EXPECT_DOUBLE_EQ(0.0, f(x0).d);
+    
+    EXPECT_DOUBLE_EQ(7.0, f(x1).a);
+    EXPECT_DOUBLE_EQ(0.0, f(x1).d);
+}

--- a/test/interpolation/linear.cc
+++ b/test/interpolation/linear.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "mathlib/interpolation/linear.hpp"
+#include "mathlib/dual_number.hpp"
 #include <iostream>
 
 TEST(LinearInterpolationTest, InterpolationTest) {
@@ -17,6 +18,58 @@ TEST(LinearInterpolationTest, InterpolationTest) {
     EXPECT_DOUBLE_EQ(1.0, f(0.0));
     EXPECT_DOUBLE_EQ(5.0, f(3.0));
     EXPECT_DOUBLE_EQ(7.0, f(4.0));
+}
+
+TEST(LinearInterpolationTest, InterpolationDualTest) {
+    auto data = std::vector {
+        std::make_pair(0.0, 1.0),
+        std::make_pair(0.5, -1.0),
+        std::make_pair(1.0, 4.0),
+        std::make_pair(2.0, 3.0),
+        std::make_pair(4.0, 7.0),
+    };
+    auto f = mathlib::intrpl::Linear(data);
+
+    ASSERT_EQ(4, f.n_segments());
+
+    auto x0 = mathlib::Dual<double>(0.0, 1.0);
+    auto x1 = mathlib::Dual<double>(3.0, 1.0);
+    auto x2 = mathlib::Dual<double>(4.0, 1.0);
+
+    EXPECT_DOUBLE_EQ(1.0, f(x0).a);
+    EXPECT_DOUBLE_EQ(-4.0, f(x0).b);
+
+    EXPECT_DOUBLE_EQ(5.0, f(x1).a);
+    EXPECT_DOUBLE_EQ(2.0, f(x1).b);
+
+    EXPECT_DOUBLE_EQ(7.0, f(x2).a);
+    EXPECT_DOUBLE_EQ(2.0, f(x2).b);
+}
+
+TEST(LinearInterpolationTest, InterpolationhyperDualTest) {
+    auto data = std::vector {
+        std::make_pair(0.0, 1.0),
+        std::make_pair(0.5, -1.0),
+        std::make_pair(1.0, 4.0),
+        std::make_pair(2.0, 3.0),
+        std::make_pair(4.0, 7.0),
+    };
+    auto f = mathlib::intrpl::Linear(data);
+
+    ASSERT_EQ(4, f.n_segments());
+
+    auto x0 = mathlib::HyperDual2<double>(0.0, 1.0, 1.0, 0.0);
+    auto x1 = mathlib::HyperDual2<double>(3.0, 1.0, 1.0, 0.0);
+    auto x2 = mathlib::HyperDual2<double>(4.0, 1.0, 1.0, 0.0);
+
+    EXPECT_DOUBLE_EQ(1.0, f(x0).a);
+    EXPECT_DOUBLE_EQ(-4.0, f(x0).b);
+
+    EXPECT_DOUBLE_EQ(5.0, f(x1).a);
+    EXPECT_DOUBLE_EQ(2.0, f(x1).b);
+
+    EXPECT_DOUBLE_EQ(7.0, f(x2).a);
+    EXPECT_DOUBLE_EQ(2.0, f(x2).b);
 }
 
 TEST(LinearInterpolationTest, DuplicatedPointInterpolationTest) {


### PR DESCRIPTION
This pull request includes significant enhancements to the interpolation functionality in the `mathlib` library, specifically adding support for dual and hyper-dual numbers in both cubic spline and linear interpolation. Additionally, it includes new unit tests to verify the correctness of these enhancements.

Enhancements to interpolation functionality:

* [`include/mathlib/interpolation/cubic_spline.hpp`](diffhunk://#diff-c71eff5e2775c871f5540e1f8e31581be3a576b96b0c394224df1f37ffba5e15R25-R26): Added support for `Dual` and `HyperDual2` number types in the `CubicSpline` class, allowing interpolation with these types. [[1]](diffhunk://#diff-c71eff5e2775c871f5540e1f8e31581be3a576b96b0c394224df1f37ffba5e15R25-R26) [[2]](diffhunk://#diff-c71eff5e2775c871f5540e1f8e31581be3a576b96b0c394224df1f37ffba5e15R62-R81)
* [`include/mathlib/interpolation/linear.hpp`](diffhunk://#diff-2f9aa9f33a9719693c17c926dc605084f9d81ba319d4a32903060b52f33009c6R26-R27): Added support for `Dual` and `HyperDual2` number types in the `Linear` class, and refactored the code to include a new `_find_segment` method to improve segment identification. [[1]](diffhunk://#diff-2f9aa9f33a9719693c17c926dc605084f9d81ba319d4a32903060b52f33009c6R26-R27) [[2]](diffhunk://#diff-2f9aa9f33a9719693c17c926dc605084f9d81ba319d4a32903060b52f33009c6R40-R41) [[3]](diffhunk://#diff-2f9aa9f33a9719693c17c926dc605084f9d81ba319d4a32903060b52f33009c6L56-R160) [[4]](diffhunk://#diff-2f9aa9f33a9719693c17c926dc605084f9d81ba319d4a32903060b52f33009c6R189-R203)

Updates to unit tests:

* [`test/interpolation/cubic_spline.cc`](diffhunk://#diff-4f53e4bcb4799f0539b20c830306746f0b360b59493c17331d55646a3f4e2720R30-R70): Added new tests `InterpolationDualTest` and `InterpolationHyperDualTest` to verify the interpolation of dual and hyper-dual numbers using the `CubicSpline` class.
* [`test/interpolation/linear.cc`](diffhunk://#diff-392028dd2fcfbfa35032984720a8ed7ac2130e22fe4db2ba4bb56bc6819641a2R3): Added new tests `InterpolationDualTest` and `InterpolationHyperDualTest` to verify the interpolation of dual and hyper-dual numbers using the `Linear` class. [[1]](diffhunk://#diff-392028dd2fcfbfa35032984720a8ed7ac2130e22fe4db2ba4bb56bc6819641a2R3) [[2]](diffhunk://#diff-392028dd2fcfbfa35032984720a8ed7ac2130e22fe4db2ba4bb56bc6819641a2R23-R74)

These changes significantly extend the capabilities of the interpolation classes, making them more versatile for advanced numerical applications.